### PR TITLE
Email display enhancements

### DIFF
--- a/basileabeam.sty
+++ b/basileabeam.sty
@@ -22,6 +22,8 @@
 % Have user add more information.
 \newcommand*{\email}[1]{\def\insertemail{#1}}
 
+
+
 % Turn off navigation symbols.
 \setbeamertemplate{navigation symbols}{}
 
@@ -167,7 +169,14 @@
     \begin{beamercolorbox}[wd=\textwidth]{author}
     {%
     	\usebeamerfont{information}%
-        \usebeamerfont{author}\insertauthor \hspace{1ex} \usebeamerfont{email}\textcolor{lcolor}{\textless \insertemail \textgreater} \\[1ex]%
+        \usebeamerfont{author}\insertauthor \hspace{1ex}
+       \usebeamerfont{email}\textcolor{lcolor}{
+       	\ifx\insertemail\@empty%
+       	\\[1ex]%
+       	\else%
+       	\textless \insertemail \textgreater \\[1ex]%
+       	\fi%
+       	} %
         \usebeamerfont{institute}\insertinstitute \\[1ex]%
         \usebeamerfont{date}\insertdate%
     }

--- a/basileabeam.sty
+++ b/basileabeam.sty
@@ -20,7 +20,8 @@
 \newcommand*{\ulistelement}[1]{\def\ulistelementint{#1}}
 
 % Have user add more information.
-\newcommand*{\email}[1]{\def\insertemail{#1}}
+%\newcommand*{\email}[1]{\def\insertemail{#1}}
+\newcommand*{\email}[1]{\ifdefined\email \def\insertemail{#1}\fi}
 
 
 
@@ -170,13 +171,13 @@
     {%
     	\usebeamerfont{information}%
         \usebeamerfont{author}\insertauthor \hspace{1ex}
-       \usebeamerfont{email}\textcolor{lcolor}{
-       	\ifx\insertemail\@empty%
+        % Email is only printed if defined by user with \email{} and there is some content
+       \ifdefined\insertemail{%
+       		\usebeamerfont{email}\textcolor{lcolor}{\textless \insertemail \textgreater}\\[1ex]%
+       }\else{%
        	\\[1ex]%
-       	\else%
-       	\textless \insertemail \textgreater \\[1ex]%
-       	\fi%
-       	} %
+    	}%
+    	\fi%
         \usebeamerfont{institute}\insertinstitute \\[1ex]%
         \usebeamerfont{date}\insertdate%
     }

--- a/basileabeam.sty
+++ b/basileabeam.sty
@@ -173,7 +173,11 @@
         \usebeamerfont{author}\insertauthor \hspace{1ex}
         % Email is only printed if defined by user with \email{} and there is some content
        \ifdefined\insertemail{%
+       		\ifx\insertemail\@empty%
+       		\\[1ex]%
+       		\else%
        		\usebeamerfont{email}\textcolor{lcolor}{\textless \insertemail \textgreater}\\[1ex]%
+       		\fi%}
        }\else{%
        	\\[1ex]%
     	}%


### PR DESCRIPTION
In the preamble of the basilea-beam style, one can state the email of the author with the control sequence `\email{}`.
Having an empty email control sequence, lead to `<>` on the title page and removing it lead to an error.

This behaviour will be fixed with this PR:

 * The `\email{}` control sequence in the preamble of the basilea-beam style is optionally now
 * The `\email{}` control sequence respects an empty argument and does not print `<>` anymore.
